### PR TITLE
Changed Makefile to work on CentOS and addedrequirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 include config.mk
 
+OS = $(shell uname)
 CFLAGS=-Wall -Werror $(INC)
 LDFLAGS=-lmicrohttpd -lcdb $(LIBS)
 
@@ -40,7 +41,7 @@ install: airportsd # airports.cdb
 	chmod 755 $(DESTDIR)$(INSTALLDIR)/share/man/man8
 	install -m 644 airportsd.8 $(DESTDIR)$(INSTALLDIR)/share/man/man8/airportsd.8
 
-	[ "$$(uname)" = "FreeBSD" ] && install -m 755 support/freebsd/airports /usr/local/etc/rc.d/airports
+	[ "$(OS)" = "FreeBSD" ] && install -m 755 support/freebsd/airports /usr/local/etc/rc.d/airports
 
 docs: airportsd.8 README.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
 include config.mk
 
-OS = $(shell uname)
 CFLAGS=-Wall -Werror $(INC)
 LDFLAGS=-lmicrohttpd -lcdb $(LIBS)
 
@@ -41,7 +40,9 @@ install: airportsd # airports.cdb
 	chmod 755 $(DESTDIR)$(INSTALLDIR)/share/man/man8
 	install -m 644 airportsd.8 $(DESTDIR)$(INSTALLDIR)/share/man/man8/airportsd.8
 
-	[ "$(OS)" = "FreeBSD" ] && install -m 755 support/freebsd/airports /usr/local/etc/rc.d/airports
+	if test "$$(uname)" = "FreeBSD"; then \
+		install -m 755 support/freebsd/airports /usr/local/etc/rc.d/airports; \
+	fi
 
 docs: airportsd.8 README.txt
 

--- a/README.txt
+++ b/README.txt
@@ -77,7 +77,10 @@ REQUIREMENTS
 	      EOF
 
    rhel/centos
-	      yum install tinycdb
+	      yum install tinycdb tinycdb-devel
+
+	      Do *not* install libmicrohttpd from the repositories,
+	      as this is way to old.
 
    debian
 	      apt‐get install tinycdb


### PR DESCRIPTION
The `[ "$$(uname}"...` construction doesn't work on CentOS 8 (`GNU Make 4.2.1`), so I changed that.
Also added the `tinycdb-devel` as a requirement for CentOS